### PR TITLE
add ref count to init/exit.

### DIFF
--- a/source/nxtc.c
+++ b/source/nxtc.c
@@ -80,7 +80,6 @@ static int nxtcEntrySortFunction(const void *a, const void *b);
 
 /* Global variables. */
 
-static bool g_nxtcInit = false;
 static Mutex g_nxtcMutex = 0;
 static u32 g_nxtcRefCount = 0;
 
@@ -144,7 +143,7 @@ bool nxtcInitialize(void)
     SCOPED_LOCK(&g_nxtcMutex)
     {
         /* Check if the interface has already been initialized. */
-        ret = g_nxtcInit;
+        ret = g_nxtcRefCount > 0;
         if (ret) break;
 
         /* Start new log session. */
@@ -158,9 +157,6 @@ bool nxtcInitialize(void)
 
         /* Load title cache file. */
         nxtcLoadFile();
-
-        /* Update flags. */
-        ret = g_nxtcInit = true;
     }
 
     /* Increment ref counter if we successfully init. */
@@ -174,7 +170,7 @@ void nxtcExit(void)
     SCOPED_LOCK(&g_nxtcMutex)
     {
         /* Check if the interface has not been initialized. */
-        if (!g_nxtcInit) break;
+        if (!g_nxtcRefCount) break;
 
         /* Decrement ref counter, if non-zero, then do not close nxtc. */
         g_nxtcRefCount--;
@@ -189,9 +185,6 @@ void nxtcExit(void)
 
         /* Close logfile. */
         nxtcLogCloseLogFile();
-
-        /* Update flags. */
-        g_nxtcInit = g_cacheFlushRequired = false;
     }
 }
 
@@ -312,7 +305,7 @@ bool nxtcGetCacheLanguage(SetLanguage *out_lang)
 
     SCOPED_LOCK(&g_nxtcMutex)
     {
-        if (!g_nxtcInit || !out_lang) {
+        if (!g_nxtcRefCount || !out_lang) {
             NXTC_LOG_MSG("Invalid parameters!");
             break;
         }
@@ -335,7 +328,7 @@ void nxtcWipeCache(void)
     SCOPED_LOCK(&g_nxtcMutex)
     {
         /* Check if the interface has already been initialized. */
-        if (!g_nxtcInit) break;
+        if (!g_nxtcRefCount) break;
 
         /* Free our title cache. */
         nxtcFreeTitleCache(false);
@@ -631,7 +624,7 @@ static void nxtcSaveFile(void)
 
     bool success = false;
 
-    if (!g_nxtcInit || !g_titleCache || !g_titleCacheCount)
+    if (!g_nxtcRefCount || !g_titleCache || !g_titleCacheCount)
     {
         NXTC_LOG_MSG("Invalid parameters!");
         return;
@@ -1092,7 +1085,7 @@ NX_INLINE u32 nxtcCalculateDataBlobSize(u16 name_len, u16 publisher_len, u32 ico
 
 static NxTitleCacheApplicationMetadata *_nxtcGetApplicationMetadataEntryById(u64 title_id)
 {
-    if (!g_nxtcInit || !g_titleCache || !g_titleCacheCount || !title_id) return NULL;
+    if (!g_nxtcRefCount || !g_titleCache || !g_titleCacheCount || !title_id) return NULL;
 
     for(u32 i = 0; i < g_titleCacheCount; i++)
     {

--- a/source/nxtc.c
+++ b/source/nxtc.c
@@ -143,24 +143,25 @@ bool nxtcInitialize(void)
     SCOPED_LOCK(&g_nxtcMutex)
     {
         /* Check if the interface has already been initialized. */
-        ret = g_nxtcRefCount > 0;
-        if (ret) break;
+        if (!g_nxtcRefCount)
+        {
+            /* Start new log session. */
+            NXTC_LOG_MSG(LIB_TITLE " v%u.%u.%u starting. Built on " BUILD_TIMESTAMP ".", LIBNXTC_VERSION_MAJOR, LIBNXTC_VERSION_MINOR, LIBNXTC_VERSION_MICRO);
 
-        /* Start new log session. */
-        NXTC_LOG_MSG(LIB_TITLE " v%u.%u.%u starting. Built on " BUILD_TIMESTAMP ".", LIBNXTC_VERSION_MAJOR, LIBNXTC_VERSION_MINOR, LIBNXTC_VERSION_MICRO);
+            /* Get system language. */
+            nxtcGetSystemLanguage();
 
-        /* Get system language. */
-        nxtcGetSystemLanguage();
+            /* Get placeholder string. */
+            g_curPlaceholderString = nxtcGetPlaceholderString();
 
-        /* Get placeholder string. */
-        g_curPlaceholderString = nxtcGetPlaceholderString();
+            /* Load title cache file. */
+            nxtcLoadFile();
+        }
 
-        /* Load title cache file. */
-        nxtcLoadFile();
+        /* Update flags. */
+        ret = true;
+        g_nxtcRefCount++;
     }
-
-    /* Increment ref counter if we successfully init. */
-    if (ret) g_nxtcRefCount++;
 
     return ret;
 }


### PR DESCRIPTION
adds a ref counter to init/exit, similar to libnx service init/exit.

minor thing, but the bool `g_nxtcInit` could in theory be replaced with the ref counter, as if the ref counter > 0, then its init. and if the ref counter == 0, then its not etc.

i can make this change if you want. 